### PR TITLE
security: update commons-io 2.2->2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
 			<artifactId>esapi</artifactId>
 			<version>2.1.0.1</version>
 		</dependency>
+		<!-- rjg: override commons-io to fix vulnerability in commons-io:2.2 transient dep in esapi -->
+		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.7</version>
+		</dependency>
 		<dependency>
 			<groupId>ognl</groupId>
 			<artifactId>ognl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>ognl</groupId>


### PR DESCRIPTION
Fix vulnerability in transient commons-io dependency of esapi